### PR TITLE
Update bundle-update-dev workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       time: "07:00"
 
   - package-ecosystem: github-actions
-    directory: bundle-update-shared
+    directory: bundle-update-prep
     schedule:
       interval: weekly
       day: thursday

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@v1
+    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@dev-update
       with:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -13,6 +13,10 @@ inputs:
   github-token:
     description: GITHUB_TOKEN for setting the PR to auto merge
     required: true
+  groups:
+    description: Groups to ignore for production gems
+    required: false
+    default: "development test"
   working-directory:
     description: Working directory for bundle update
     required: false
@@ -28,7 +32,7 @@ runs:
         working-directory: ${{ inputs.working-directory }}
     - run: |
         bundle list --name-only > .gems-all
-        bundle list --name-only --without-group test development > .gems-prod
+        bundle list --name-only --without-group ${{ inputs.groups }} > .gems-prod
         cat .gems-all .gems-prod | sort | uniq -u > .gems-update
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -30,6 +30,10 @@ runs:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}
         working-directory: ${{ inputs.working-directory }}
+    - run: bundle install
+      if: ${{ inputs.container != 'false' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - run: |
         bundle list --name-only > .gems-all
         bundle list --name-only --without-group ${{ inputs.groups }} > .gems-prod

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -34,6 +34,7 @@ runs:
         bundle list --name-only > .gems-all
         bundle list --name-only --without-group ${{ inputs.groups }} > .gems-prod
         cat .gems-all .gems-prod | sort | uniq -u > .gems-update
+        cat .gems-update
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - run: xargs -a .gems-update bundle update --conservative
@@ -52,10 +53,10 @@ runs:
         delete-branch: true
         labels: dependencies, ruby
         title: Bundle Update [development, test]
-    - name: Enable auto-merge
-      if: steps.cpr.outputs.pull-request-operation == 'created'
-      run: gh pr merge "$PR_URL" --auto --delete-branch --squash
-      shell: bash
-      env:
-        PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+#    - name: Enable auto-merge
+#      if: steps.cpr.outputs.pull-request-operation == 'created'
+#      run: gh pr merge "$PR_URL" --auto --delete-branch --squash
+#      shell: bash
+#      env:
+#        PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+#        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -1,5 +1,5 @@
 name: Bundle Update [development, test]
-description: Run `bundle update --group development test`; create a PR for any updates; and set the PR to auto-merge
+description: Run `bundle update --conservative` for non-production gems; create a PR for any updates; and set the PR to auto-merge
 author: Faculty Development Team
 
 inputs:
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@dev-update
+    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@v1
       with:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}
@@ -51,16 +51,16 @@ runs:
       id: cpr
       uses: peter-evans/create-pull-request@v4
       with:
-        body: Changes after running `bundle update --group development test --conservative`
+        body: Changes after running `bundle update --conservative` for non-production gems
         branch: bundle-update-dev
-        commit-message: bundle update --group development test --conservative
+        commit-message: bundle update --conservative for non-production gems
         delete-branch: true
         labels: dependencies, ruby
-        title: Bundle Update [development, test]
-#    - name: Enable auto-merge
-#      if: steps.cpr.outputs.pull-request-operation == 'created'
-#      run: gh pr merge "$PR_URL" --auto --delete-branch --squash
-#      shell: bash
-#      env:
-#        PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-#        GITHUB_TOKEN: ${{ inputs.github-token }}
+        title: Bundle Update [non-production gems]
+    - name: Enable auto-merge
+      if: steps.cpr.outputs.pull-request-operation == 'created'
+      run: gh pr merge "$PR_URL" --auto --delete-branch --squash
+      shell: bash
+      env:
+        PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -23,10 +23,21 @@ runs:
   steps:
     - uses: university-of-york/faculty-dev-actions/bundle-update-shared@v1
       with:
-        arguments: --group development test --conservative
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}
         working-directory: ${{ inputs.working-directory }}
+    - run: |
+        bundle list --name-only > .gems-all
+        bundle list --name-only --without-group test development > .gems-prod
+        cat .gems-all .gems-prod | sort | uniq -u > .gems-update
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+    - run: xargs -a .gems-update bundle update --conservative
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+    - run: rm .gems-*
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - name: Create Pull Request
       id: cpr
       uses: peter-evans/create-pull-request@v4

--- a/bundle-update-dev/action.yml
+++ b/bundle-update-dev/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@v1
+    - uses: university-of-york/faculty-dev-actions/bundle-update-prep@v1
       with:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}

--- a/bundle-update-prep/action.yml
+++ b/bundle-update-prep/action.yml
@@ -1,5 +1,5 @@
-name: Bundle Update (shared)
-description: Run tasks to prepare for running `bundle update`
+name: Bundle Update Preparation
+description: Preparations for running `bundle update`
 author: Faculty Development Team
 
 inputs:

--- a/bundle-update-shared/action.yml
+++ b/bundle-update-shared/action.yml
@@ -3,10 +3,6 @@ description: Run bundle update
 author: Faculty Development Team
 
 inputs:
-  arguments:
-    description: Arguments to pass to `bundle update`
-    required: false
-    default: ""
   checkout-key:
     description: Key to use when checking out the repository
     required: true
@@ -33,8 +29,5 @@ runs:
       shell: bash
     - run: bundle config --local deployment false
       if: ${{ inputs.container == 'false' }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-    - run: bundle update ${{ inputs.arguments }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/bundle-update-shared/action.yml
+++ b/bundle-update-shared/action.yml
@@ -1,5 +1,5 @@
 name: Bundle Update (shared)
-description: Run bundle update
+description: Run tasks to prepare for running `bundle update`
 author: Faculty Development Team
 
 inputs:

--- a/bundle-update/action.yml
+++ b/bundle-update/action.yml
@@ -23,6 +23,9 @@ runs:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}
         working-directory: ${{ inputs.working-directory }}
+    - run: bundle update --all
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:

--- a/bundle-update/action.yml
+++ b/bundle-update/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/bundle-update-shared@v1
+    - uses: university-of-york/faculty-dev-actions/bundle-update-prep@v1
       with:
         checkout-key: ${{ inputs.checkout-key }}
         container: ${{ inputs.container }}


### PR DESCRIPTION
Instead of only updating dev/test gems explicitly defined in Gemfiles, we can generate a list of non-production gems and update those (conservatively).

`bundle list --name-only --without-group` will fail if the group does not exist, so gems calling this workflow will need to pass in `development` to the groups argument (as our gems don't define a `test` group).

Tested with sinatra-base.