### PR TITLE
rubocop: Add support for selecting the ruby version

### DIFF
--- a/rubocop/action.yml
+++ b/rubocop/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Working directory for Gemfile
     required: false
     default: ./
+  ruby-version:
+    description: Sets the ruby version you want to build with.
+    required: false
+    default: 2.7
 
 runs:
   using: composite
@@ -14,6 +18,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     - run: |


### PR DESCRIPTION
    This just allows this action to run with a selected ruby version
    Defaults to 2.7 so as not to break anything. Will need updating
    at the end of 2023.

I'm trying to update some code to work with 3.2 ruby as 2.7 support is going from AWS soon.
This is just the first patch to these actions to support setting the version. If this is not the right way then happy for a better option :)

This pr is an example of where this is going to be needed. https://github.com/university-of-york/faculty-dev-rake-gem/pull/117

#yakshave
