### PR TITLE
Update rspec and audit to support ruby versions

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -7,13 +7,18 @@ inputs:
     description: Working directory for Gemfile
     required: false
     default: ./
+  ruby-version:
+    description: Sets the ruby version you want to build with.
+    required: false
+    default: 2.7
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     # See https://jira.york.ac.uk/browse/FD-594 for CVE-2015-9284

--- a/rspec-runner/action.yml
+++ b/rspec-runner/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Working directory for Gemfile
     required: false
     default: ./
+  ruby-version:
+    description: Sets the ruby version you want to build with.
+    required: false
+    default: 2.7
 
 runs:
   using: composite
@@ -14,6 +18,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     - run: bundle exec rspec


### PR DESCRIPTION
This adds the ruby version option to the rspec and audit steps.

This is the same as the rubocop one. The rspec one is probably the critical one but audtit can't hurt :)

This will then let me test the rake gem across all versions that we claim to support.

I've also bumped the checkout action to v3 ( I'll save the v4 pull requests for another day )