### PR TITLE
Create a new ruby-command action that takes a ruby version

### DIFF
--- a/ruby-command/action.yaml
+++ b/ruby-command/action.yaml
@@ -1,0 +1,18 @@
+
+name: Ruby container command
+description: Run a command within our ruby container
+inputs:
+  command:
+    description: Command to run
+    required: true
+  ruby-version:
+    description: Ruby version to run, 3.2 or 2.7 currently
+    required: true
+
+runs:
+  using: docker
+  image: docker://ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:${{ inputs.ruby-version }}
+  args:
+    - bash
+    - -c
+    - ${{ inputs.command }}


### PR DESCRIPTION
   This a generic ruby command that requires a ruby version.
   This is used in the apps for bundle install on aws deployment

Needs: https://github.com/university-of-york/faculty-dev-docker-images/pull/20/files