### PR TITLE
Use an extra step to get the ruby-version in docker image

### DIFF
--- a/ruby-command/action.yaml
+++ b/ruby-command/action.yaml
@@ -10,9 +10,19 @@ inputs:
     required: true
 
 runs:
-  using: docker
-  image: docker://ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:${{ inputs.ruby-version }}
-  args:
-    - bash
-    - -c
-    - ${{ inputs.command }}
+  using: composite
+  steps:
+     # This step is here just because we can't use the
+     # inputs data in an "image:" setting.
+   - name: set ruby version
+     id: ruby-ver
+     runs-on: ubuntu-latest
+     outputs:
+       image: docker://ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:${{ inputs.ruby-version }}
+
+   - name: Run command
+     image: ${{ steps.ruby-ver.outputs.image }}
+     args:
+      - bash
+      - -c
+      - ${{ inputs.command }}


### PR DESCRIPTION
   You can't see the "inputs" contexts in the "image:" setting for a step.
   https://stackoverflow.com/questions/59191913/how-do-i-get-the-output-of-a-specific-step-in-github-actions
   So we add in yet another step to get the variable which can then be used.
   There is probably a line somewhere in githubs docs that explain this but I'm
   not sure I can see it.

   My hope is this will fix the following error:

    Error:
      university-of-york/faculty-dev-actions/v1/ruby-command/action.yaml
      (Line: 14, Col: 10):
      Unrecognized named-value: 'inputs'. Located at position 1
      within expression: inputs.ruby-version
    Error: Fail to load university-of-york/faculty-dev-actions/v1/ruby-command/action.yaml