### PR TITLE
Respect .ruby-version by default

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -10,7 +10,7 @@ inputs:
   ruby-version:
     description: Sets the ruby version you want to build with.
     required: false
-    default: 2.7
+    default: 'default'
 
 runs:
   using: composite

--- a/rspec-runner/action.yml
+++ b/rspec-runner/action.yml
@@ -10,7 +10,7 @@ inputs:
   ruby-version:
     description: Sets the ruby version you want to build with.
     required: false
-    default: 2.7
+    default: 'default'
 
 runs:
   using: composite

--- a/rubocop/action.yml
+++ b/rubocop/action.yml
@@ -10,7 +10,7 @@ inputs:
   ruby-version:
     description: Sets the ruby version you want to build with.
     required: false
-    default: 2.7
+    default: 'default'
 
 runs:
   using: composite


### PR DESCRIPTION
We use this in our apps to reduce duplication of the version number.

When this option was added for the gems, we made this default to 2.7 - which I think was over- cautious.
