### PR TITLE
Add exception for CVE-2024-21510 for bundle audit action

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -22,6 +22,6 @@ runs:
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     # See https://jira.york.ac.uk/browse/FD-594 for CVE-2015-9284
-    - run: bundle exec bundler-audit check --update --ignore CVE-2015-9284
+    - run: bundle exec bundler-audit check --update --ignore CVE-2015-9284 CVE-2024-21510
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
See FD-2143 for the details. Essentially, we need to add a temporary exception for https://www.cve.org/CVERecord?id=CVE-2024-21510. 