### PR TITLE
FD-2182: update artifact actions to v4

### DIFF
--- a/rspec-lambda-github-formatter/action.yml
+++ b/rspec-lambda-github-formatter/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: actions/checkout@v3
     - run: bundle install --deployment --without development
       shell: bash
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       if: ${{ inputs.artifact-name != 'false' }}
       with:
         name: ${{ inputs.artifact-name }}

--- a/rspec-lambda/action.yml
+++ b/rspec-lambda/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: actions/checkout@v3
     - run: bundle install --deployment --without development
       shell: bash
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       if: ${{ inputs.artifact-name != 'false' }}
       with:
         name: ${{ inputs.artifact-name }}

--- a/vue-build/action.yml
+++ b/vue-build/action.yml
@@ -27,7 +27,7 @@ runs:
     - run: npx webpack --config webpack.prod.js
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: vue-components
         path: ${{ inputs.working-directory }}public/js/**


### PR DESCRIPTION
Does what it says on the tin: bump up the `download` and `upload` `artifacts` actions from v3 (deprecated) to v4.

From looking at the docs, this shouldn't require any further changes in this repo. However, it's mentioned that some firewall rules may need to be added/updated: [breaking changes to artifact actions](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes ). If we're running into issues, then this may be the culprit - so we'll need to raise a support case with IT Services.

The additional migration steps don't look to be relevant here (i.e. we don't upload to the same artifact multiple times in the same workflow run), so I _think_ we can just bump up the version number and call it a day.