### PR TITLE
FD-2183: Bump checkout action version from v3 to v4 (latest available)

### DIFF
--- a/bundle-update-prep/action.yml
+++ b/bundle-update-prep/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ssh-key: ${{ inputs.checkout-key }}
     - uses: ruby/setup-ruby@v1

--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/gemfury-deploy/action.yml
+++ b/gemfury-deploy/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/npm-update/action.yml
+++ b/npm-update/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ssh-key: ${{ inputs.checkout-key }}
     - uses: actions/setup-node@v4

--- a/rspec-lambda-github-formatter/action.yml
+++ b/rspec-lambda-github-formatter/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: bundle install --deployment --without development
       shell: bash
     - uses: actions/download-artifact@v4

--- a/rspec-lambda/action.yml
+++ b/rspec-lambda/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: bundle install --deployment --without development
       shell: bash
     - uses: actions/download-artifact@v4

--- a/rspec-runner-github-formatter/action.yml
+++ b/rspec-runner-github-formatter/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/rspec-runner/action.yml
+++ b/rspec-runner/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/rubocop/action.yml
+++ b/rubocop/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}

--- a/vue-build/action.yml
+++ b/vue-build/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}

--- a/web-library-update/action.yml
+++ b/web-library-update/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ssh-key: ${{ inputs.checkout-key }}
     - run: |


### PR DESCRIPTION
Checkout v3 will be deprecated soon, so bump to v4. As per the docs, this shouldn't involve any other changes to workflow files. 