### PR TITLE
DRY-ing up deploy workflow action for our on-prem apps

### DIFF
--- a/deploy-legacy-on-prem/action.yml
+++ b/deploy-legacy-on-prem/action.yml
@@ -11,6 +11,7 @@ inputs:
     required: true
 
 runs:
+  using: composite
   steps:
     - uses: actions/checkout@v4
     - name: Deploy

--- a/deploy-legacy-on-prem/action.yml
+++ b/deploy-legacy-on-prem/action.yml
@@ -3,37 +3,21 @@ description: Deploy onto a on-premise server
 author: Faculty Development Team
 
 inputs:
-  deploy-environment:
-    description: Deployment environment name
+  deploy-server:
+    description: Server to deploy to
     required: true
-  deploy-branch:
-    description: Branch to deploy from
+  ssh-key:
+    description: SSH key for remote user
     required: true
-    default: main
 
 runs:
-  on:
-  push:
-    branches:
-      - ${{ inputs.deploy-branch }}
+  steps:
+  - uses: actions/checkout@v4
 
-  jobs:
-    deployment:
-      name: Deploy to servers
-      runs-on: [self-hosted, Linux, X64]
-      strategy:
-        fail-fast: false
-        matrix:
-          environment: [${{ inputs.deploy-environment }}]
-      environment: ${{ matrix.environment }}
-
-      steps:
-        - uses: actions/checkout@v4
-
-        - name: Deploy
-          uses: docker://ghcr.io/university-of-york/sys-docker-rsyncssh-image/ci/rsyncssh:1
-          env:
-            SERVER: ${{ vars.DEPLOY_SSH_HOST }}
-            RSYNC_USER: 'cdeploy-rsync'
-            SSH_USER: 'cdeploy-ssh'
-            SSH_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+  - name: Deploy
+    uses: docker://ghcr.io/university-of-york/sys-docker-rsyncssh-image/ci/rsyncssh:1
+    env:
+  SERVER: ${{ inputs.deploy-server }}
+  RSYNC_USER: 'cdeploy-rsync'
+  SSH_USER: 'cdeploy-ssh'
+  SSH_KEY: ${{ inputs.ssh-key }}

--- a/deploy-legacy-on-prem/action.yml
+++ b/deploy-legacy-on-prem/action.yml
@@ -12,12 +12,11 @@ inputs:
 
 runs:
   steps:
-  - uses: actions/checkout@v4
-
-  - name: Deploy
-    uses: docker://ghcr.io/university-of-york/sys-docker-rsyncssh-image/ci/rsyncssh:1
-    env:
-  SERVER: ${{ inputs.deploy-server }}
-  RSYNC_USER: 'cdeploy-rsync'
-  SSH_USER: 'cdeploy-ssh'
-  SSH_KEY: ${{ inputs.ssh-key }}
+    - uses: actions/checkout@v4
+    - name: Deploy
+      uses: docker://ghcr.io/university-of-york/sys-docker-rsyncssh-image/ci/rsyncssh:1
+      env:
+        SERVER: ${{ inputs.deploy-server }}
+        RSYNC_USER: 'cdeploy-rsync'
+        SSH_USER: 'cdeploy-ssh'
+        SSH_KEY: ${{ inputs.ssh-key }}

--- a/deploy-legacy-on-prem/action.yml
+++ b/deploy-legacy-on-prem/action.yml
@@ -1,0 +1,39 @@
+name: Deploy on Legacy On-Prem Server
+description: Deploy onto a on-premise server
+author: Faculty Development Team
+
+inputs:
+  deploy-environment:
+    description: Deployment environment name
+    required: true
+  deploy-branch:
+    description: Branch to deploy from
+    required: true
+    default: main
+
+runs:
+  on:
+  push:
+    branches:
+      - ${{ inputs.deploy-branch }}
+
+  jobs:
+    deployment:
+      name: Deploy to servers
+      runs-on: [self-hosted, Linux, X64]
+      strategy:
+        fail-fast: false
+        matrix:
+          environment: [${{ inputs.deploy-environment }}]
+      environment: ${{ matrix.environment }}
+
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Deploy
+          uses: docker://ghcr.io/university-of-york/sys-docker-rsyncssh-image/ci/rsyncssh:1
+          env:
+            SERVER: ${{ vars.DEPLOY_SSH_HOST }}
+            RSYNC_USER: 'cdeploy-rsync'
+            SSH_USER: 'cdeploy-ssh'
+            SSH_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,35 @@ jobs:
       - uses: university-of-york/faculty-dev-actions/bundler-audit@v1
 ```
 
+## deploy-legacy-on-prem
+
+Deploys the application onto an on-premise server, via the `sys-docker-rsyncssh-image` docker action.
+
+### Inputs
+
+* `deploy-server`: the name of the webserver to deploy to
+* `ssh-key`: the SSH key of the SSH user on the webserver
+
+### Example
+
+```yaml
+jobs:
+  deployment:
+    name: Deploy to servers
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [prod]
+    environment: ${{ matrix.environment }}
+
+    steps:
+      - uses: university-of-york/faculty-dev-actions/deploy-legacy-on-prem@legacy-deploy-action
+        with:
+          deploy-server: ${{ vars.DEPLOY_SSH_HOST }}
+          ssh-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+```
+
 ## gemfury-deploy
 
 Deploys the named gem to gemfury


### PR DESCRIPTION
# Context
See FD-2183 ([link](https://uoy.atlassian.net/browse/FD-2183?atlOrigin=eyJpIjoiNGM4ZTU2MzA4NmNmNGNhNzhmNjRmYjk0Y2I4YTM4YzciLCJwIjoiaiJ9)) for some additional context.

Basically, most of our on-premise applications (e.g. the EE and CS ones) use almost the exact same deployment workflow for getting the code on the webservers. This new action DRYs things up a bit.

# Implementation
I've basically just copied from the current `.github/workflows/deploy.yml` files in most of our legacy apps.

I've tested on EE Attendance ([link](https://github.com/university-of-york/faculty-dev-ee-attendance)), and it runs fine.

There's also a README section for the new action as well.