### PR TITLE
Add CVE-2025-61921 to exceptions

### DIFF
--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -22,6 +22,7 @@ runs:
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     # See https://jira.york.ac.uk/browse/FD-594 for CVE-2015-9284
+    # See https://github.com/sinatra/sinatra/security/advisories/GHSA-mr3q-g2mv-mr4q for CVE-2025-61921
     - run: bundle exec bundler-audit check --update --ignore CVE-2015-9284 CVE-2024-21510 CVE-2025-61921
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/bundler-audit/action.yml
+++ b/bundler-audit/action.yml
@@ -22,6 +22,6 @@ runs:
         bundler-cache: true
         working-directory: ${{ inputs.working-directory }}
     # See https://jira.york.ac.uk/browse/FD-594 for CVE-2015-9284
-    - run: bundle exec bundler-audit check --update --ignore CVE-2015-9284 CVE-2024-21510
+    - run: bundle exec bundler-audit check --update --ignore CVE-2015-9284 CVE-2024-21510 CVE-2025-61921
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Sinatra should be upgraded to 4.2.0. In the meantime, this should be an exception for vuln CVE-2025-61921

[ReDoS vulnerability in ETag generation](https://github.com/sinatra/sinatra/security/advisories/GHSA-mr3q-g2mv-mr4q)