### PR TITLE
FD-2327: update deploy action

### DIFF
--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -10,6 +10,5 @@ inputs:
 runs:
   using: composite
   steps:
-    - name:
     - run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
       shell: bash

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake deploy:to['${{ inputs.aws-environment }}','github']
+      run: gem install rake && rake deploy:to['${{ inputs.aws-environment }}','github','GithubActionsDeploymentRole']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -16,6 +16,8 @@ runs:
   steps:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
+      permissions:
+        contents: write
       with:
         ruby-version: 'default'
         bundler-cache: true

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
+      run: gem install rake && bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -6,9 +6,21 @@ inputs:
   aws-environment:
     description: AWS Environment (dev, staging, prod)
     required: true
+  working-directory:
+    description: Working directory for Gemfile
+    required: false
+    default: ./
 
 runs:
   using: composite
   steps:
-    - run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 'default'
+        bundler-cache: true
+        working-directory: ${{ inputs.working-directory }}
+    - name: Deploy via rake deploy task
+      run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
       shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -11,13 +11,14 @@ inputs:
     required: false
     default: ./
 
+permissions:
+  contents: write
+
 runs:
   using: composite
   steps:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
-      permissions:
-        contents: write
       with:
         ruby-version: 'default'
         bundler-cache: true

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake deploy:to['${{ inputs.aws-environment }}', 'github']
+      run: gem install rake && rake -T && rake deploy:to['${{ inputs.aws-environment }}', 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake deploy:to['"${{ inputs.aws-environment }}"', 'github']
+      run: gem install rake && rake deploy:to[${{ inputs.aws-environment }}, 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake -T && rake deploy:to['${{ inputs.aws-environment }}', 'github']
+      run: gem install rake && rake deploy:to['${{ inputs.aws-environment }}','github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake deploy:to["${{ inputs.aws-environment }}", 'github']
+      run: gem install rake && rake deploy:to['"${{ inputs.aws-environment }}"', 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && rake deploy:to[${{ inputs.aws-environment }}, 'github']
+      run: gem install rake && rake deploy:to['${{ inputs.aws-environment }}', 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -3,65 +3,13 @@ description: Deploy to cloudformation
 author: Faculty Development Team
 
 inputs:
-  aws-account-id:
-    description: AWS Account ID
-    required: true
   aws-environment:
     description: AWS Environment (dev, staging, prod)
     required: true
-  parameter-overrides:
-    description: Parameter overrides for cloudformation
-    required: false
-  s3bucket:
-    description: S3 bucket for uploading code
-    required: true
-  stack-name:
-    description: Stack name for cloudformation
-    required: true
-    default: ${{ github.event.repository.name }}
-  tag-name:
-    description: Name of the app
-    required: true
-  template:
-    description: Template file name
-    required: true
-    default: cloudformation.yaml
 
 runs:
   using: composite
   steps:
-    - run: >
-        aws cloudformation package
-        --template-file ${{ inputs.template }}
-        --output-template-file serverless-output.yaml 
-        --s3-bucket ${{ inputs.s3bucket }}
-      shell: bash
-
-    - run: |
-        ARGS=""
-        if [ -n "${{ inputs.parameter-overrides }}" ] 
-        then
-          ARGS="$ARGS --parameter-overrides ${{ inputs.parameter-overrides }} "
-        fi
-        
-        TAGS_ARRAY=(york/policy_version=2 \ 
-        york/name=\"${{ inputs.tag-name }}\" \ 
-        york/group=FACULTY-DEV \
-        york/project=${{ github.repository }} \
-        york/status=${{ inputs.aws-environment }} \ 
-        york/pushed_by=github \
-        york/defined_in=cloudformation \ 
-        york/repo_name=${{ github.repository }} \
-        )
-        TAGS="--tags ${TAGS_ARRAY[@]}"
-        
-        array=(aws cloudformation deploy \
-        --template-file serverless-output.yaml \
-        --stack-name ${{ inputs.stack-name }} \
-        --capabilities CAPABILITY_IAM \
-        --role-arn ${{ format('arn:aws:iam::{0}:role/GithubActionsDeploymentRole', inputs.aws-account-id) }} \
-        --no-fail-on-empty-changeset \
-        $ARGS $TAGS)
-        
-        eval $(echo ${array[@]})
+    - name:
+    - run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
       shell: bash

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -11,9 +11,6 @@ inputs:
     required: false
     default: ./
 
-permissions:
-  contents: write
-
 runs:
   using: composite
   steps:

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 'default'
-        bundler-cache: true
+        bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
       run: bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']

--- a/sam-deploy/action.yml
+++ b/sam-deploy/action.yml
@@ -24,6 +24,6 @@ runs:
         bundler-cache: false
         working-directory: ${{ inputs.working-directory }}
     - name: Deploy via rake deploy task
-      run: gem install rake && bundle exec rake deploy:to["${{ inputs.aws-environment }}", 'github']
+      run: gem install rake && rake deploy:to["${{ inputs.aws-environment }}", 'github']
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
# Context

There's a bit of a history here, see [FD-2327](https://uoy.atlassian.net/browse/FD-2327?atlOrigin=eyJpIjoiZjhmNWIxYjk4NWQyNDZkNmExMzk2YTc1NGVmM2I5MDQiLCJwIjoiaiJ9) for more details.

This is the change to the `sam-deploy` action to make it use our `rake deploy:to` task to deploy to AWS.

# Implementation

This change simplifies things a great deal, mostly as the AWS CLI commands are now performed by the rake task. Several parameters aren't needed anymore, as various values (e.g. the `s3bucket` parameter) are basically constant and not secrets, so they've been moved into the rake configs. 

# Plan

I'm not planning on merging this just yet, as the various sinatra-base app repos aren't yet configured to use this new `sam-deploy` action. So the plan is:
1. Raise PRs with changes to the apps' repos, namely updating their `deploy` workflow files and ensure they have the correct rake config to work with this new action
2. Merge those PRs into the apps' `main` branch, and expect deployments to temp. not work until step 3 is complete
3. Merge this PR into `v1` so it's available to the `deploy` workflows of our apps


[FD-2327]: https://uoy.atlassian.net/browse/FD-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ