### PR TITLE
FD-2401: Replace bundle install flags with bundle config commands

### DIFF
--- a/rspec-lambda-github-formatter/action.yml
+++ b/rspec-lambda-github-formatter/action.yml
@@ -16,7 +16,10 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - run: bundle install --deployment --without development
+    - run: |
+        export BUNDLE_DEPLOYMENT=true
+        export BUNDLE_WITHOUT=deployment
+        bundle install
       shell: bash
     - uses: actions/download-artifact@v4
       if: ${{ inputs.artifact-name != 'false' }}

--- a/rspec-lambda-github-formatter/action.yml
+++ b/rspec-lambda-github-formatter/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: actions/checkout@v4
     - run: |
         export BUNDLE_DEPLOYMENT=true
-        export BUNDLE_WITHOUT=deployment
+        export BUNDLE_WITHOUT=development
         bundle install
       shell: bash
     - uses: actions/download-artifact@v4

--- a/rspec-lambda-github-formatter/action.yml
+++ b/rspec-lambda-github-formatter/action.yml
@@ -17,8 +17,8 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - run: |
-        export BUNDLE_DEPLOYMENT=true
-        export BUNDLE_WITHOUT=development
+        bundle config set deployment true
+        bundle config set without development
         bundle install
       shell: bash
     - uses: actions/download-artifact@v4

--- a/rspec-lambda/action.yml
+++ b/rspec-lambda/action.yml
@@ -16,7 +16,10 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - run: bundle install --deployment --without development
+    - run: |
+        export BUNDLE_DEPLOYMENT=true
+        export BUNDLE_WITHOUT=deployment
+        bundle install
       shell: bash
     - uses: actions/download-artifact@v4
       if: ${{ inputs.artifact-name != 'false' }}

--- a/rspec-lambda/action.yml
+++ b/rspec-lambda/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: actions/checkout@v4
     - run: |
         export BUNDLE_DEPLOYMENT=true
-        export BUNDLE_WITHOUT=deployment
+        export BUNDLE_WITHOUT=development
         bundle install
       shell: bash
     - uses: actions/download-artifact@v4

--- a/rspec-lambda/action.yml
+++ b/rspec-lambda/action.yml
@@ -17,8 +17,8 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - run: |
-        export BUNDLE_DEPLOYMENT=true
-        export BUNDLE_WITHOUT=development
+        bundle config set deployment true
+        bundle config set without development
         bundle install
       shell: bash
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
It looks like the various flags for `bundle install` are now deprecated / removed in favour of setting them via `bundle config` or via environment variables. I've opted for the former, as I can't seem to get the latter to work.

Note that the `rspec-lambda` action isn't actually used anywhere, but I figured I'd update it too.

I've tested this with a new branch in `faculty-dev-sinatra-base`, and it seems to work OK.