### PR TITLE
FD-2413: Create new 'bundle-install-deploy' action

### DIFF
--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -7,10 +7,14 @@ inputs:
     description: Colon-separated list of Gem groups not to install
     required: false
     default: test:development
+  bundle-clean:
+    description: Wherever or not to run "bundle clean" after "bundle install"
+    required: false
+    default: true
 
 runs:
   using: composite
   steps:
     - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
       with:
-        command: bundle config set deployment true without ${{ inputs.without-gem-groups }} && bundle install
+        command: bundle config set deployment true without ${{ inputs.without-gem-groups }} clean ${{ inputs.bundle- }} && bundle install

--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -1,0 +1,16 @@
+name: Bundle Install Deploy
+description: Run bundle install command for deployment to AWS
+author: Workflow Improvement Team
+
+inputs:
+  without-gem-groups:
+    description: Colon-separated list of Gem groups not to install
+    required: false
+    default: test:development
+
+runs:
+  using: composite
+  steps:
+    - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
+      with:
+        command: bundle config set deployment true without ${{ inputs.without-gem-groups }} && bundle install

--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -3,7 +3,7 @@ description: Run bundle install command for deployment to AWS
 author: Workflow Improvement Team
 
 inputs:
-  without-gem-groups:
+  bundle-without:
     description: Colon-separated list of Gem groups not to install
     required: false
     default: test:development

--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -3,14 +3,14 @@ description: Run bundle install command for deployment to AWS
 author: Workflow Improvement Team
 
 inputs:
-  bundle-without:
-    description: Colon-separated list of Gem groups not to install
-    required: false
-    default: test:development
   bundle-clean:
     description: Wherever or not to run "bundle clean" after "bundle install"
     required: false
     default: true
+  bundle-without:
+    description: Colon-separated list of Gem groups not to install
+    required: false
+    default: test:development
 
 runs:
   using: composite

--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -4,7 +4,7 @@ author: Workflow Improvement Team
 
 inputs:
   bundle-clean:
-    description: Wherever or not to run "bundle clean" after "bundle install"
+    description: Whether or not to run "bundle clean" after "bundle install"
     required: false
     default: true
   bundle-without:

--- a/bundle-install-deploy/action.yml
+++ b/bundle-install-deploy/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Whether or not to run "bundle clean" after "bundle install"
     required: false
     default: true
+  bundle-deploy:
+    description: Whether or not to run bundle install in "deployment" mode
+    required: false
+    default: true
   bundle-without:
     description: Colon-separated list of Gem groups not to install
     required: false
@@ -17,4 +21,4 @@ runs:
   steps:
     - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
       with:
-        command: bundle config set deployment true without ${{ inputs.without-gem-groups }} clean ${{ inputs.bundle- }} && bundle install
+        command: bundle config set deployment ${{ inputs.bundle-deploy }} without ${{ inputs.without-gem-groups }} clean ${{ inputs.bundle- }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -1,5 +1,5 @@
-name: Bundle Install Deploy
-description: Run bundle install command for deployment to AWS
+name: Bundle Install
+description: Run bundle install command
 author: Workflow Improvement Team
 
 inputs:

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ bundle config set deployment true without test:development clean true && bundle 
 ### Inputs
 
 * `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
-* `bundle-clean`: (optional) boolean `true` or `false`. Wherever or not to have `bundle clean` run after `bundle install`. Defaults to `true`.
+* `bundle-clean`: (optional) boolean `true` or `false`. Whether to have `bundle clean` run after `bundle install`. Defaults to `true`.
 
 ### Example
 With common defaults (so ignoring `development` and `test` gem groups and have `bundle clean` run after install):

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,11 @@ bundle config set deployment true without test:development clean true && bundle 
 ### Inputs
 
 * `bundle-clean`: (optional) boolean `true` or `false`. Whether to have `bundle clean` run after `bundle install`. Defaults to `true`.
+* `bundle-deploy`: (optional) boolean `true` or `false`. Whether to set `deployment` flag. Defaults to `true`.
 * `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
 
 ### Example
-With common defaults (so ignoring `development` and `test` gem groups and have `bundle clean` run after install):
+With common defaults, so ignoring `development` and `test` gem groups, enabling `deployment` mode and have `bundle clean` run after install:
 
 ```yaml
 name: Deploy

--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,8 @@ bundle config set deployment true without test:development clean true && bundle 
 
 ### Inputs
 
-* `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
 * `bundle-clean`: (optional) boolean `true` or `false`. Whether to have `bundle clean` run after `bundle install`. Defaults to `true`.
+* `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
 
 ### Example
 With common defaults (so ignoring `development` and `test` gem groups and have `bundle clean` run after install):

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ The content of this repository is made available to the public under
 the MIT license, as others may find our dev / CI setup useful - or at
 least educational.
 
-## bundle-install-deploy
+## bundle-install
 
 Run `bundle install` with standard config settings for deployments beforehand (via `bundle config`). With default
 parameters this will end up being:
@@ -14,6 +14,8 @@ parameters this will end up being:
 ```sh
 bundle config set deployment true without test:development clean true && bundle install
 ```
+
+I.e. suitable for AWS deployments.
 
 ### Inputs
 
@@ -42,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Bundle install
-        uses: university-of-york/faculty-dev-actions/bundle-install-deploy
+        uses: university-of-york/faculty-dev-actions/bundle-install
 
 # ...
 ```
@@ -51,7 +53,7 @@ If `bundle clean` wasn't required and only the `test` gem group needs to be igno
 ```yaml
 # ...
 - name: Bundle install
-    uses: university-of-york/faculty-dev-actions/bundle-install-deploy
+    uses: university-of-york/faculty-dev-actions/bundle-install
     with:
       bundle-without: test
       bundle-clean: false

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ bundle config set deployment true without test:development clean true && bundle 
 
 ### Inputs
 
-* `without-gem-groups`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
+* `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
 * `bundle-clean`: (optional) boolean `true` or `false`. Wherever or not to have `bundle clean` run after `bundle install`. Defaults to `true`.
 
 ### Example
@@ -52,7 +52,7 @@ If `bundle clean` wasn't required and only the `test` gem group needs to be igno
 - name: Bundle install
     uses: university-of-york/faculty-dev-actions/bundle-install-deploy
     with:
-      without-gem-groups: test
+      bundle-without: test
       bundle-clean: false
 # ...
 ```

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,63 @@ The content of this repository is made available to the public under
 the MIT license, as others may find our dev / CI setup useful - or at
 least educational.
 
+## bundle-install-deploy
+
+Run `bundle install` with standard config settings for deployments beforehand (via `bundle config`). With default
+parameters this will end up being:
+
+```sh
+bundle config set deployment true without test:development clean true && bundle install
+```
+
+### Inputs
+
+* `without-gem-groups`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
+* `bundle-clean`: (optional) boolean `true` or `false`. Wherever or not to have `bundle clean` run after `bundle install`. Defaults to `true`.
+
+### Example
+With common defaults (so ignoring `development` and `test` gem groups and have `bundle clean` run after install):
+
+```yaml
+name: Deploy
+
+# ...
+
+jobs:
+  aws-deployment:
+    name: Deploy to AWS
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        environment: ['dev', 'staging', 'prod']
+    environment: ${{ matrix.environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle install
+        uses: university-of-york/faculty-dev-actions/bundle-install-deploy
+
+# ...
+```
+
+If `bundle clean` wasn't required and only the `test` gem group needs to be ignored:
+```yaml
+# ...
+- name: Bundle install
+    uses: university-of-york/faculty-dev-actions/bundle-install-deploy
+    with:
+      without-gem-groups: test
+      bundle-clean: false
+# ...
+```
+
+This will basically end up running:
+
+```sh
+bundle config set deployment true without test clean false && bundle install
+```
+
 ## bundle-update
 
 Run `bundle update` against a repository and create a pull request with any changes.


### PR DESCRIPTION
Add (new) action for bundle install command with standard options for deployments. It seems to be a fairly common usage throughout our workflows, so it makes sense to encapsulate it. 

fd-2413