### PR TITLE
FD-2413: Split bundle config commands

### DIFF
--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: Whether or not to run "bundle clean" after "bundle install"
     required: false
     default: true
-  bundle-deploy:
+  bundle-deployment:
     description: Whether or not to run bundle install in "deployment" mode
     required: false
     default: true
@@ -21,4 +21,4 @@ runs:
   steps:
     - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
       with:
-        command: bundle config set deployment ${{ inputs.bundle-deploy }} && bundle config set without ${{ inputs.without-gem-groups }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install
+        command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -21,4 +21,4 @@ runs:
   steps:
     - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
       with:
-        command: bundle config set deployment ${{ inputs.bundle-deploy }} without ${{ inputs.without-gem-groups }} clean ${{ inputs.bundle-clean }} && bundle install
+        command: bundle config set deployment ${{ inputs.bundle-deploy }} && bundle config set without ${{ inputs.without-gem-groups }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install


### PR DESCRIPTION
`bundle config set` can only accept one key config parameter at a time, so split command into three (one for each config key).

fd-2413