### PR TITLE
FD-2348: add ruby-3.4-command action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @university-of-york/faculty-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @university-of-york/faculty-dev
+* @university-of-york/workflow-improvement-team-web-developers

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -23,7 +23,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Bundle update with Ruby 3.2
-      uses: university-of-york/faculty-dev-actions/ruby-${{ inputs.ruby-version }}-command@v1
+    - uses: university-of-york/faculty-dev-actions/ruby-${{ inputs.ruby-version }}-command@v1
       with:
         command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -15,10 +15,14 @@ inputs:
     description: Colon-separated list of Gem groups not to install
     required: false
     default: test:development
+  ruby-version:
+    description: The major & minor-point Ruby version to use, e.g. '3.4' for Ruby 3.4
+    required: false
+    default: 3.2
 
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/ruby-3.4-command@v1
+    - uses: university-of-york/faculty-dev-actions/ruby-${{ inputs.ruby-version }}-command@v1
       with:
         command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -23,6 +23,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/ruby-${{ inputs.ruby-version }}-command@v1
+    - name: Bundle update with Ruby 3.2
+      if: ${{ inputs.ruby-version == '3.2' }}
+      uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
+      with:
+        command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install
+
+    - name: Bundle update with Ruby 3.4
+      if: ${{ inputs.ruby-version == '3.4' }}
+      uses: university-of-york/faculty-dev-actions/ruby-3.4-command@v1
       with:
         command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -18,7 +18,7 @@ inputs:
   ruby-version:
     description: The major & minor-point Ruby version to use, e.g. '3.4' for Ruby 3.4
     required: false
-    default: 3.2
+    default: '3.2'
 
 runs:
   using: composite

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -24,13 +24,6 @@ runs:
   using: composite
   steps:
     - name: Bundle update with Ruby 3.2
-      if: ${{ inputs.ruby-version == '3.2' }}
-      uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
-      with:
-        command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install
-
-    - name: Bundle update with Ruby 3.4
-      if: ${{ inputs.ruby-version == '3.4' }}
-      uses: university-of-york/faculty-dev-actions/ruby-3.4-command@v1
+      uses: university-of-york/faculty-dev-actions/ruby-${{ inputs.ruby-version }}-command@v1
       with:
         command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/bundle-install/action.yml
+++ b/bundle-install/action.yml
@@ -19,6 +19,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: university-of-york/faculty-dev-actions/ruby-3.2-command@v1
+    - uses: university-of-york/faculty-dev-actions/ruby-3.4-command@v1
       with:
         command: bundle config set deployment ${{ inputs.bundle-deployment }} && bundle config set without ${{ inputs.bundle-without }} && bundle config set clean ${{ inputs.bundle-clean }} && bundle install

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,9 @@ bundle config set deployment true without test:development clean true && bundle 
 
 I.e. suitable for AWS deployments.
 
+**Note**: this will run the `bundle install` command in a Docker container, resulting in the gems being installed
+in `./vendor/bundle` in the project directory in the runner.
+
 ### Inputs
 
 * `bundle-clean`: (optional) boolean `true` or `false`. Whether to have `bundle clean` run after `bundle install`. Defaults to `true`.

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ in `./vendor/bundle` in the project directory in the runner.
 * `bundle-clean`: (optional) boolean `true` or `false`. Whether to have `bundle clean` run after `bundle install`. Defaults to `true`.
 * `bundle-deploy`: (optional) boolean `true` or `false`. Whether to set `deployment` flag. Defaults to `true`.
 * `bundle-without`: (optional) **colon-separated** list of gem groups to ignore during `bundle install`. Defaults to `test:development`.
+* `ruby-version`: (optional) string, specifies the `ruby-X.X-command` action e.g. "3.2" will ensure `ruby-3.2-command` is used. Defaults to `3.2`.
 
 ### Example
 With common defaults, so ignoring `development` and `test` gem groups, enabling `deployment` mode and have `bundle clean` run after install:
@@ -67,6 +68,16 @@ This will basically end up running:
 
 ```sh
 bundle config set deployment true without test clean false && bundle install
+```
+
+Use Ruby 3.4 instead of 3.2 (the default):
+```yaml
+# ...
+- name: Bundle install
+    uses: university-of-york/faculty-dev-actions/bundle-install
+    with:
+      ruby-version: "3.2"
+# ...
 ```
 
 ## bundle-update

--- a/ruby-3.4-command/action.yaml
+++ b/ruby-3.4-command/action.yaml
@@ -1,0 +1,15 @@
+
+name: Ruby container command 3.4
+description: Run a command within our ruby 3.4 container
+inputs:
+  command:
+    description: Command to run
+    required: true
+
+runs:
+  using: docker
+  image: docker://ghcr.io/university-of-york/faculty-dev-docker-images/ci/aws-lambda-ruby-dev:3.4
+  args:
+    - bash
+    - -c
+    - ${{ inputs.command }}


### PR DESCRIPTION
# Context

Some of our non-Sinatra-Base-based repos use the `bundle-install` action for the `deploy` workflow, which itself just uses a `ruby-X.X-command` action to run `bundle install`. Previously this `bundle-install` action is hard-coded to use `ruby-3.2-command`, which we need to update to 3.4 for our move to the 3.4 stack.

# Implementation

I've introduced a new `ruby-3.4-command` action, which is pretty much identical to the 3.2 one except for just one obvious change.

I've then updated the `bundle-install` action to use it.

# Which repos use `bundle-install`?

A quick `grep` shows the following:
- `faculty-dev-aws-fargate-monitor` - `deploy` workflow
- `faculty-dev-rds-version-monitor` - `deploy` workflow
- `faculty-dev-aws-load-balancer-priority` - `deploy` workflow
- `faculty-dev-mailing-list-generator` - `deploy` workflow

We want all these serverless apps on Ruby 3.4. As the `bundle-install` action is only used in the `deploy` workflow, if this change is merged I'll migrate the apps to 3.4.

# Discussion

I'm not sure extracting the `bundle install` process for these repos into an action was a good idea in hindsight; it now means that migrating to a new runtime will inherently involve breaking the `deploy` workflows for the above apps until they're moved over.  